### PR TITLE
Set guest_os_type to "Ubuntu_64" for VirtualBox packer build

### DIFF
--- a/automation/packer/testlab-dev.json
+++ b/automation/packer/testlab-dev.json
@@ -41,6 +41,7 @@
       "iso_url": "http://cdimage.ubuntu.com/releases/18.04.2/release/ubuntu-18.04.2-server-amd64.iso",
       "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
       "iso_checksum_type": "sha256",
+      "guest_os_type": "Ubuntu_64",
       "vm_name": "testlab-dev",
       "ssh_username": "{{user `local_ssh_username`}}",
       "ssh_password": "{{user `local_ssh_password`}}",


### PR DESCRIPTION
When building on OS X, the VirtualBox build would get stuck with
the message:

“This kernel requires an x86-64 CPU, but only detected an i686 CPU.”

<img width="428" alt="Screenshot 2019-06-03 15 18 48" src="https://user-images.githubusercontent.com/20886/58838893-dd31b100-8614-11e9-9804-d4501710f4d8.png">

In the Packer docs for virtualbox-iso, it says:

https://www.packer.io/docs/builders/virtualbox-iso.html#guest_os_type

guest_os_type (string) - The guest OS type being installed. By default this is other, but you can get dramatic performance improvements by setting this to the proper value. To view all available values for this run VBoxManage list ostypes. Setting the correct value hints to VirtualBox how to optimize the virtual hardware to work best with that operating system.

Setting this value to Ubuntu_64 fixes the build problem.