### PR TITLE
More fixes for virtualbox + vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 build/
+*.box

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ vm-binary: $(shell find . -type f -name '*.go')
 vm: vm-binary $(shell find automation/packer -type f)
 	PACKER_CACHE_DIR=./automation/packer/packer_cache packer build automation/packer/testlab-dev.json
 
+vm-virtualbox: vm-binary $(shell find automation/packer -type f)
+	PACKER_CACHE_DIR=./automation/packer/packer_cache packer build -only=virtualbox-iso automation/packer/testlab-dev.json
+
 vm-vmware: vm-binary $(shell find automation/packer -type f)
 	PACKER_CACHE_DIR=./automation/packer/packer_cache packer build -only=vmware-iso automation/packer/testlab-dev.json

--- a/automation/packer/config/nomad.service
+++ b/automation/packer/config/nomad.service
@@ -12,7 +12,7 @@ After=consul.service
 [Service]
 KillMode=process
 KillSignal=SIGINT
-ExecStart=/usr/local/bin/nomad agent -config-file=/ops/config/nomad.hcl
+ExecStart=/usr/local/bin/nomad agent -config=/ops/config/nomad.hcl
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=2

--- a/automation/packer/testlab-dev.json
+++ b/automation/packer/testlab-dev.json
@@ -111,7 +111,12 @@
       "inline": [
         "mv /ops/config/consul.service /etc/systemd/system/consul.service",
         "mv /ops/config/nomad.service /etc/systemd/system/nomad.service",
-        "mv /ops/testlab /usr/local/bin/"
+        "mv /ops/testlab /usr/local/bin/",
+        "echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers",
+        "echo 'Defaults:ubuntu !requiretty' >> /etc/sudoers",
+        "(test -f /home/ubuntu/VBoxGuestAdditions.iso && mount /home/ubuntu/VBoxGuestAdditions.iso /mnt -o ro && sh /mnt/VBoxLinuxAdditions.run) || true",
+        "systemctl enable consul",
+        "systemctl enable nomad"
       ]
     }
   ],


### PR DESCRIPTION
Some more fixes for virtualbox + vagrant.

Added a "make vm-virtualbox" target.

Start up consult + nomad automatically.

Also fixed a problem in the nomad startup script.