### PR TITLE
add ssh timeout

### DIFF
--- a/automation/packer/testlab-dev.json
+++ b/automation/packer/testlab-dev.json
@@ -45,6 +45,7 @@
       "vm_name": "testlab-dev",
       "ssh_username": "{{user `local_ssh_username`}}",
       "ssh_password": "{{user `local_ssh_password`}}",
+      "ssh_timeout": "20m",
       "shutdown_command": "echo '{{user `local_ssh_password`}}' | sudo -S shutdown -P now",
       "floppy_files": ["automation/packer/preseed/ks.cfg"],
       "boot_wait": "10s",


### PR DESCRIPTION
Maybe it is just my machine but packer doesn't get through the setting up of the OS before packer's ssh timeout is reached.